### PR TITLE
Deleting words less than the length chosen by the user

### DIFF
--- a/Crumble.cpp
+++ b/Crumble.cpp
@@ -21,7 +21,7 @@ void delWords(int del_L) {
     
     //looks for words with specified letter count
     while (getline(WordIFILE, StoreWord)) {
-        if (StoreWord.length() != del_L) {
+        if (StoreWord.length() > del_L) {
             OutFile << StoreWord << endl;
 
         }


### PR DESCRIPTION
Deleting words less than the length chosen by the user is more useful in practice